### PR TITLE
Add request progress listener (#2)

### DIFF
--- a/maven.gradle
+++ b/maven.gradle
@@ -7,7 +7,7 @@ ext {
     artifact = 'dc-volley'
 
     libraryDescription = 'A Library Project improvements to Volley'
-    libraryVersion = '1.3.1'
+    libraryVersion = '1.3.2'
 
     gitUrl = 'https://github.com/DoveConviene/dc-volley.git'
     siteUrl = 'https://github.com/DoveConviene/dc-volley'

--- a/src/main/java/com/android/volley/Response.java
+++ b/src/main/java/com/android/volley/Response.java
@@ -49,6 +49,24 @@ public class Response<T> {
     }
 
     /**
+     * Callback interface for delivering the progress of the responses.
+     */
+    public interface ProgressListener {
+
+        /**
+         * Callback called each time byte chunks are downloaded
+         *
+         * @param progress         Progress percentage from 0 to 100
+         * @param transferredBytes Downloaded bytes
+         * @param totalSize        Total response size
+         * @param millisSpent      Current time spent on download
+         * @param retryCount       Current request retries
+         */
+        public void onProgress(int progress, long transferredBytes, long totalSize, long millisSpent, int retryCount);
+
+    }
+
+    /**
      * Returns a successful response containing the parsed result.
      *
      * @param result     A result of the expected type

--- a/src/test/java/com/android/volley/toolbox/ImageRequestTest.java
+++ b/src/test/java/com/android/volley/toolbox/ImageRequestTest.java
@@ -130,7 +130,7 @@ public class ImageRequestTest {
     private void verifyResize(NetworkResponse networkResponse, int maxWidth, int maxHeight,
                               ScaleType scaleType, int expectedWidth, int expectedHeight) {
         ImageRequest request = new ImageRequest("", null, maxWidth, maxHeight, scaleType,
-                Config.RGB_565, null);
+                Config.RGB_565, null, null);
         Response<Bitmap> response = request.parseNetworkResponse(networkResponse);
         assertNotNull(response);
         assertTrue(response.isSuccess());
@@ -170,9 +170,9 @@ public class ImageRequestTest {
     public void publicMethods() throws Exception {
         // Catch-all test to find API-breaking changes.
         assertNotNull(ImageRequest.class.getConstructor(String.class, Response.Listener.class,
-                int.class, int.class, Bitmap.Config.class, Response.ErrorListener.class));
+                int.class, int.class, Bitmap.Config.class, Response.ErrorListener.class, Response.ProgressListener.class));
         assertNotNull(ImageRequest.class.getConstructor(String.class, Response.Listener.class,
                 int.class, int.class, ImageView.ScaleType.class, Bitmap.Config.class,
-                Response.ErrorListener.class));
+                Response.ErrorListener.class, Response.ProgressListener.class));
     }
 }


### PR DESCRIPTION
* Add requests progress listener. Image downloads have now track of progress

* Add possibility to change ImageRequest default retry policy

* Better progress management. Tested in app. Manages slow speed notification

* Reformat code

* Better DefaultRetryPolicy setting

* Reset retryCount DefaultRetryPolicy for ImageRequest

* Fix javadoc

* Add integer progress to base onProgress listener

* Remove ImageLoader general retry policy

* Simplify progress listener. Fix volley tests

* Upgrade maven version

* Rename variable

* Remove unused import

* Add ImageRequest constructor without ProgressListener